### PR TITLE
Add command usage to help message (closes #1)

### DIFF
--- a/commands/help.js
+++ b/commands/help.js
@@ -7,13 +7,31 @@ module.exports = {
   guildOnly: true, // does this command only work in a guild?
   adminOnly: false, // is this command only for admins?
   async execute(client, db, message, args) {
-    var helptext = "```"
+    if (args.length == 0) {
+      await module.exports.list_all(client, message);
+    } else {
+      await module.exports.cmd_usage(client, message, args[0].toLowerCase());
+    }
+  },
+  async list_all(client, message) {
+    var helptext = "```\n"
     client.commands.forEach(command => {
       if(!command.adminOnly) {
         helptext += command.name + ":\n\t" + command.description + "\n"
       }
     });
     helptext += "```\n"
+    message.channel.send(helptext);
+  },
+  async cmd_usage(client, message, name) {
+    const cmd = client.commands.get(name)
+    || client.commands.find(c => c.aliases && c.aliases.includes(name));
+    if (cmd == null || cmd.adminOnly) return;
+
+    var helptext = "```\n" + `${cmd.name}:\n`;
+    // not all commands have specific usage syntax
+    if (cmd.usage != null) helptext += `\tUsage: !${cmd.usage}\n\n`;
+    helptext += `\t${cmd.description}` + "```\n";
     message.channel.send(helptext);
   },
 }


### PR DESCRIPTION
Specifically, only when a command is provided as an argument.

Looks like:
![image](https://user-images.githubusercontent.com/605854/75596383-594f0d00-5a5e-11ea-915d-34ab79d6aeda.png)

Closes #1.